### PR TITLE
ethplorer: Sync token transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ sh ./db_init.sh
 * Coinbase Pro
 * Gemini
 * Bitcoin addresses, x/y pub (no bech3/bc1 addresses yet).
-* Ethereum and ERC20 tokens (no transaction support yet, only balances).
+* Ethereum and ERC20 tokens
+  * Up to 1000 ERC20 token transactions
+  * No ETH transactions


### PR DESCRIPTION
Up to 1000 items. The timestamp parameter doesn't seem to work as I expect. ethplorer will return transactions on either side of a timestamp, I'm not sure if it's counting up or down