### PR TITLE
transactions: Add "line" for each transaction

### DIFF
--- a/src/fdb.erl
+++ b/src/fdb.erl
@@ -155,6 +155,7 @@ schema() ->
                 #{name => "integration_id", type => "uuid"},
                 #{name => "external_id", type => "text"},
                 #{name => "source_id", type => "text"},
+                #{name => "line", type => "text"},
                 #{name => "direction", type => "text"},
                 #{name => "timestamp", type => "timestamp"},
                 #{name => "symbol", type => "text"},
@@ -162,7 +163,7 @@ schema() ->
                 #{name => "type", type => "text"},
                 #{name => "description", type => "text"}
             ],
-            primary_key => ["integration_id", "external_id", "source_id"]
+            primary_key => ["integration_id", "external_id", "source_id", "line"]
         }
     ].
 

--- a/src/folio_blockstream.erl
+++ b/src/folio_blockstream.erl
@@ -219,6 +219,7 @@ blockstream_tx_to_transactions(
             {Include, TXAttrs} = addrinfo_to_attrs(Addr, AddrInfo),
             TX = maps:merge(TXAttrs, #{
                 source_id => TXID,
+                line => <<"">>,
                 datetime => BlockTime,
                 type => undefined,
                 symbol => <<"BTC">>,
@@ -243,6 +244,7 @@ blockstream_tx_to_transactions(
             Include = TXAddr == Addr,
             TX = #{
                 source_id => TXID,
+                line => <<"">>,
                 datetime => BlockTime,
                 amount => sats_to_btc(Value),
                 type => undefined,

--- a/src/folio_coinbase_api.erl
+++ b/src/folio_coinbase_api.erl
@@ -176,6 +176,7 @@ cb_to_tx(
         maps:merge(Partial, #{
             datetime => DT,
             source_id => SourceID,
+            line => <<"">>,
             amount => decimal:abs(folio_math:to_decimal(Amount)),
             symbol => Symbol,
             type => undefined

--- a/src/folio_coinbase_pro_api.erl
+++ b/src/folio_coinbase_pro_api.erl
@@ -124,6 +124,7 @@ cb_to_txs(
         end,
     #{
         source_id => LedgerID,
+        line => <<"">>,
         datetime => qdate:to_date(CreatedAt),
         direction => Direction,
         symbol => Currency,
@@ -150,6 +151,7 @@ cb_to_txs(
         end,
     #{
         source_id => LedgerID,
+        line => <<"">>,
         datetime => qdate:to_date(CreatedAt),
         direction => Direction,
         symbol => Currency,
@@ -171,6 +173,7 @@ cb_to_txs(
 ) ->
     #{
         source_id => LedgerID,
+        line => <<"">>,
         datetime => qdate:to_date(CreatedAt),
         direction => out,
         symbol => Currency,
@@ -199,6 +202,7 @@ cb_to_txs(
         end,
     #{
         source_id => LedgerID,
+        line => <<"">>,
         datetime => qdate:to_date(CreatedAt),
         direction => Direction,
         symbol => Currency,
@@ -224,6 +228,7 @@ cb_to_txs(
         end,
     #{
         source_id => LedgerID,
+        line => <<"">>,
         datetime => qdate:to_date(CreatedAt),
         direction => Direction,
         symbol => Currency,

--- a/src/folio_ethplorer.erl
+++ b/src/folio_ethplorer.erl
@@ -151,6 +151,7 @@ op_to_txs(Addr, #{
     [
         #{
             source_id => TXHash,
+            line => <<"">>,
             datetime => qdate:to_date(Timestamp),
             direction => Direction,
             symbol => Symbol,
@@ -176,6 +177,7 @@ api_tx_to_txs(Addr, #{
     [
         #{
             source_id => TXHash,
+            line => <<"">>,
             datetime => qdate:to_date(Timestamp),
             direction => Direction,
             symbol => <<"ETH">>,

--- a/src/folio_fetcher.erl
+++ b/src/folio_fetcher.erl
@@ -300,6 +300,7 @@ write_account_transactions(#{id := IntegrationID}, _Account = #{id := AccountID}
                 fun(
                     _T = #{
                         source_id := SourceID,
+                        line := Line,
                         datetime := DT,
                         direction := Direction,
                         symbol := Symbol,
@@ -312,6 +313,7 @@ write_account_transactions(#{id := IntegrationID}, _Account = #{id := AccountID}
                         integration_id => IntegrationID,
                         external_id => AccountID,
                         source_id => SourceID,
+                        line => Line,
                         timestamp => DT,
                         direction => Direction,
                         symbol => Symbol,

--- a/src/folio_gemini_api.erl
+++ b/src/folio_gemini_api.erl
@@ -253,11 +253,11 @@ transfers_to_folio_txs(
     Amount = folio_math:to_decimal(AmountBin),
 
     ID = erlang:integer_to_binary(IDInt),
-    SourceID = <<<<"transfers.">>/binary, ID/binary>>,
     Description = <<Type/binary, <<" ">>/binary, Status/binary>>,
 
     TX = #{
-        source_id => SourceID,
+        source_id => ID,
+        line => <<"">>,
         datetime => qdate:to_date(trunc(TSMS / 1000)),
         symbol => Currency,
         type => undefined,
@@ -279,8 +279,6 @@ trades_to_folio_txs(
 ) ->
     {Left, Right} = tradepair_to_currency(TradePair),
     IDB = erlang:integer_to_binary(ID),
-    LeftID = <<IDB/binary, <<".">>/binary, Left/binary>>,
-    RightID = <<IDB/binary, <<".">>/binary, Right/binary>>,
     Amount = folio_math:to_decimal(AmountBin),
     Price = folio_math:to_decimal(PriceBin),
 
@@ -293,7 +291,8 @@ trades_to_folio_txs(
         end,
 
     LeftTX = #{
-        source_id => LeftID,
+        source_id => IDB,
+        line => Left,
         datetime => qdate:to_date(TS),
         symbol => Left,
         type => undefined,
@@ -302,7 +301,8 @@ trades_to_folio_txs(
         amount => Amount
     },
     RightTX = #{
-        source_id => RightID,
+        source_id => IDB,
+        line => Right,
         datetime => qdate:to_date(TS),
         symbol => Right,
         direction => RightDir,
@@ -333,6 +333,7 @@ earn_to_folio_txs(
 ) ->
     Default = #{
         source_id => ID,
+        line => <<"">>,
         datetime => qdate:to_date(trunc(DT / 1000)),
         symbol => Currency,
         amount => folio_math:to_decimal(AmountFloat)

--- a/src/folio_integration.erl
+++ b/src/folio_integration.erl
@@ -53,6 +53,7 @@
 -export_type([account_transaction/0]).
 -type account_transaction() :: #{
     source_id := binary(),
+    line := binary(),
     datetime := calendar:datetime(),
     direction := in | out,
     symbol := binary(),

--- a/src/folio_loopring.erl
+++ b/src/folio_loopring.erl
@@ -176,6 +176,7 @@ transfer_to_txs(
     [
         #{
             source_id => TXHash,
+            line => <<"">>,
             datetime => qdate:to_date(trunc(TimestampMS / 1000)),
             direction => Direction,
             symbol => Symbol,

--- a/test/folio_blockstream_test.erl
+++ b/test/folio_blockstream_test.erl
@@ -170,6 +170,7 @@ accounts_transactions_test() ->
             direction := out,
             source_id :=
                 <<"8529be643ed0200777afa7b389debec28b8ece52a0318d98575b6a107c19e529">>,
+            line := <<"">>,
             symbol := <<"BTC">>,
             type := undefined
         },

--- a/test/folio_gemini_api_test.erl
+++ b/test/folio_gemini_api_test.erl
@@ -135,7 +135,8 @@ accounts_exchange_transactions_test() ->
 
     ?assertMatch(
         #{
-            source_id := <<"107317526.BTC">>,
+            source_id := <<"107317526">>,
+            line := <<"BTC">>,
             datetime := {{1970, 1, 1}, {0, 0, 10}},
             direction := in,
             symbol := <<"BTC">>,
@@ -147,7 +148,8 @@ accounts_exchange_transactions_test() ->
     ),
     ?assertMatch(
         #{
-            source_id := <<"107317526.USD">>,
+            source_id := <<"107317526">>,
+            line := <<"USD">>,
             datetime := {{1970, 1, 1}, {0, 0, 10}},
             direction := out,
             symbol := <<"USD">>,
@@ -159,7 +161,8 @@ accounts_exchange_transactions_test() ->
     ),
     ?assertMatch(
         #{
-            source_id := <<"107317527.BTC">>,
+            source_id := <<"107317527">>,
+            line := <<"BTC">>,
             datetime := {{1970, 1, 1}, {0, 0, 20}},
             direction := out,
             symbol := <<"BTC">>,
@@ -171,7 +174,8 @@ accounts_exchange_transactions_test() ->
     ),
     ?assertMatch(
         #{
-            source_id := <<"107317527.USD">>,
+            source_id := <<"107317527">>,
+            line := <<"USD">>,
             datetime := {{1970, 1, 1}, {0, 0, 20}},
             direction := in,
             symbol := <<"USD">>,
@@ -183,7 +187,8 @@ accounts_exchange_transactions_test() ->
     ),
     ?assertMatch(
         #{
-            source_id := <<"transfers.320033681">>,
+            source_id := <<"320033681">>,
+            line := <<"">>,
             datetime := {{1970, 1, 1}, {0, 0, 10}},
             direction := in,
             symbol := <<"USD">>,
@@ -195,7 +200,8 @@ accounts_exchange_transactions_test() ->
     ),
     ?assertMatch(
         #{
-            source_id := <<"transfers.320033682">>,
+            source_id := <<"320033682">>,
+            line := <<"">>,
             datetime := {{1970, 1, 1}, {0, 0, 20}},
             direction := out,
             symbol := <<"USD">>,
@@ -207,7 +213,8 @@ accounts_exchange_transactions_test() ->
     ),
     ?assertMatch(
         #{
-            source_id := <<"transfers.320033683">>,
+            source_id := <<"320033683">>,
+            line := <<"">>,
             datetime := {{1970, 1, 1}, {0, 0, 20}},
             direction := in,
             symbol := <<"USD">>,
@@ -221,6 +228,7 @@ accounts_exchange_transactions_test() ->
     ?assertMatch(
         #{
             source_id := <<"GHIJK34L5">>,
+            line := <<"">>,
             datetime := {{1970, 1, 1}, {0, 1, 40}},
             direction := out,
             symbol := <<"BTC">>,


### PR DESCRIPTION
To keep multi-leg transactions together with the same source transaction ID that has multiple lines with varied direction/fees