### PR TITLE
http: Built-in http 429 handling

### DIFF
--- a/src/folio_http.erl
+++ b/src/folio_http.erl
@@ -132,6 +132,9 @@ request(Method, URL, Headers, ReqBody, ErrorFun) ->
                     ErrorFun();
                 {error, timeout} ->
                     ErrorFun();
+                {ok, 429, RespHeaders, Body} ->
+                    folio_throttle:sleep(1000),
+                    ErrorFun();
                 {ok, RespCode, RespHeaders, Body} ->
                     ?set_attributes([{<<"https.status_code">>, RespCode}]),
                     case jsx:is_json(Body) of

--- a/src/folio_throttle.erl
+++ b/src/folio_throttle.erl
@@ -3,7 +3,7 @@
 -include_lib("opentelemetry_api/include/otel_tracer.hrl").
 -include_lib("kernel/include/logger.hrl").
 
--export([setup/3, rate_limit/2]).
+-export([setup/3, rate_limit/2, sleep/1]).
 
 setup(Domain, Rate, Time) ->
     throttle:setup(Domain, Rate, Time).

--- a/test/folio_http_test.erl
+++ b/test/folio_http_test.erl
@@ -1,0 +1,48 @@
+-module(folio_http_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(MUT, folio_http).
+-define(MOCK_MODS, [hackney, folio_throttle, {fake_mod, [non_strict]}]).
+
+load() ->
+    folio_meck:load(?MOCK_MODS),
+    ok.
+
+http_request_429_test() ->
+    load(),
+
+    Method = get,
+    URL = <<"http://example.com">>,
+    Headers = [],
+    Body = [],
+
+    ok = meck:expect(
+        folio_throttle,
+        sleep,
+        ['_'],
+        ok
+    ),
+    ok = meck:expect(
+        hackney,
+        request,
+        [
+            {[get, URL, [], [], [with_body]], {ok, 429, [], <<>>}}
+        ]
+    ),
+    ok = meck:expect(
+        fake_mod,
+        error_fun,
+        [],
+        ok
+    ),
+
+    ?MUT:request(Method, URL, Headers, Body, fun fake_mod:error_fun/0),
+
+    [{sleep, [1000]}] = folio_meck:history_calls(folio_throttle),
+    [{request, RequestArgs}] = folio_meck:history_calls(hackney),
+    [{error_fun, []}] = folio_meck:history_calls(fake_mod),
+
+    ?assertMatch([get, URL, [], [], [with_body]], RequestArgs),
+
+    folio_meck:unload(?MOCK_MODS).


### PR DESCRIPTION
Sleep for 1 second, then try the error fun

This should help with rate limiting (most in gemini) when the throttle isn't quite right. This is mostly due to running dev and deployed instances from the same public IP