### PR TITLE
fetcher: Set int state as error if run was failing

### DIFF
--- a/src/folio_fetcher.erl
+++ b/src/folio_fetcher.erl
@@ -213,11 +213,13 @@ handle_info({'EXIT', From, Reason}, State = #{pid_info_map := PidInfoMap}) ->
         still_running => StillRunning,
         pid_info_map => PidInfoMap
     }),
+    {ok, LastState} = folio_integration:get_integration_state(Integration),
     SyncState =
-        case {StillRunning, Reason} of
-            {false, normal} -> complete;
-            {true, normal} -> running;
-            {_, _} -> error
+        case {LastState, StillRunning, Reason} of
+            {error, _, _} -> error;
+            {_, false, normal} -> complete;
+            {_, true, normal} -> running;
+            {_, _, _} -> error
         end,
     folio_integration:set_integration_state(Integration, SyncState),
     {noreply, State#{pid_info_map => NewPidInfoMap}};

--- a/test/folio_fetcher_test.erl
+++ b/test/folio_fetcher_test.erl
@@ -29,6 +29,12 @@ gen_server_sync_no_accounts_test() ->
         {ok, Integrations}
     ),
     ok = meck:expect(
+        folio_integration,
+        get_integration_state,
+        ['_'],
+        {ok, running}
+    ),
+    ok = meck:expect(
         folio_account_provider,
         fetch_integration_accounts,
         ['_'],
@@ -47,7 +53,59 @@ gen_server_sync_no_accounts_test() ->
         {integrations, [Conn]},
         {set_integration_state, [Int1, starting]},
         {write_accounts, [Conn, Int1, []]},
+        {get_integration_state, [Int1]},
         {set_integration_state, [Int1, complete]}
+    ] =
+        folio_meck:history_calls(folio_integration),
+
+    folio_meck:unload(?MOCK_MODS).
+
+gen_server_sync_no_accounts_with_previous_error_test() ->
+    load(),
+
+    Conn = fdb_test:expect_fdb_checkout(),
+    fdb_test:expect_fdb_checkin(Conn),
+    expect_set_integration_state(),
+    expect_timer_apply_interval(),
+    expect_write_accounts(),
+    expect_write_account_transactions(),
+
+    Int1 = #{id => <<"id1">>, provider_name => <<"name1">>},
+    Integrations = [Int1],
+
+    ok = meck:expect(
+        folio_integration,
+        integrations,
+        [Conn],
+        {ok, Integrations}
+    ),
+    ok = meck:expect(
+        folio_integration,
+        get_integration_state,
+        ['_'],
+        {ok, error}
+    ),
+    ok = meck:expect(
+        folio_account_provider,
+        fetch_integration_accounts,
+        ['_'],
+        {ok, []}
+    ),
+
+    {ok, _Pid} = ?MUT:start_link(),
+    pong = ?MUT:ping(),
+    ?MUT:sync(),
+
+    meck:wait(folio_integration, set_integration_state, [Int1, error], 3000),
+
+    ok = ?MUT:stop(),
+    2 = fdb_test:assert_checkouts_matches_checkins(),
+    [
+        {integrations, [Conn]},
+        {set_integration_state, [Int1, starting]},
+        {write_accounts, [Conn, Int1, []]},
+        {get_integration_state, [Int1]},
+        {set_integration_state, [Int1, error]}
     ] =
         folio_meck:history_calls(folio_integration),
 
@@ -76,6 +134,12 @@ gen_server_sync_accounts_no_txs_test() ->
         integrations,
         [Conn],
         {ok, Integrations}
+    ),
+    ok = meck:expect(
+        folio_integration,
+        get_integration_state,
+        ['_'],
+        {ok, running}
     ),
     ok = meck:expect(
         folio_account_provider,
@@ -118,7 +182,9 @@ gen_server_sync_accounts_no_txs_test() ->
                 }
             ]
         ]},
+        {get_integration_state, [Int2]},
         {set_integration_state, [Int2, running]},
+        {get_integration_state, [Int2]},
         {set_integration_state, [Int2, complete]}
     ] =
         folio_meck:history_calls(folio_integration),

--- a/test/folio_http_test.erl
+++ b/test/folio_http_test.erl
@@ -39,8 +39,8 @@ http_request_429_test() ->
 
     ?MUT:request(Method, URL, Headers, Body, fun fake_mod:error_fun/0),
 
-    [{sleep, [1000]}] = folio_meck:history_calls(folio_throttle),
     [{request, RequestArgs}] = folio_meck:history_calls(hackney),
+    [{sleep, [1000]}] = folio_meck:history_calls(folio_throttle),
     [{error_fun, []}] = folio_meck:history_calls(fake_mod),
 
     ?assertMatch([get, URL, [], [], [with_body]], RequestArgs),


### PR DESCRIPTION
If the last state was error than don't change the state

A new run will set "starting" and any errors after that will keep an "error" state